### PR TITLE
Update path validation for api management api

### DIFF
--- a/azurerm/helpers/validate/api_management.go
+++ b/azurerm/helpers/validate/api_management.go
@@ -71,7 +71,7 @@ func ApiManagementApiName(v interface{}, k string) (ws []string, es []error) {
 func ApiManagementApiPath(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 
-	if matched := regexp.MustCompile(`^(?:|[\w][\w-/.]{0,398}[\w-])$`).Match([]byte(value)); !matched {
+	if matched := regexp.MustCompile(`^(?:|[\w.][\w-/.]{0,398}[\w-])$`).Match([]byte(value)); !matched {
 		es = append(es, fmt.Errorf("%q may only be up to 400 characters in length, not start or end with `/` and only contain valid url characters", k))
 	}
 	return ws, es

--- a/azurerm/helpers/validate/api_management_test.go
+++ b/azurerm/helpers/validate/api_management_test.go
@@ -127,6 +127,10 @@ func TestAzureRMApiManagementApiPath_validation(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
+			Value:    ".well-known",
+			ErrCount: 0,
+		},
+		{
 			Value:    s.Repeat("x", 401),
 			ErrCount: 1,
 		},


### PR DESCRIPTION
Adding support for paths that start with the character '.'

This is important for path implementations such as ".well-known" in universal links